### PR TITLE
added spinix.ext.napoleon to sphinx extensions

### DIFF
--- a/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'matplotlib.sphinxext.plot_directive',
-    'numpydoc',
     'sphinx_copybutton',
     'autoapi.extension',
     'sphinx.ext.napoleon'

--- a/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -43,7 +43,8 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'numpydoc',
     'sphinx_copybutton',
-    'autoapi.extension'
+    'autoapi.extension',
+    'sphinx.ext.napoleon'
 ]
 
 # Configuration options for plot_directive. See:


### PR DESCRIPTION
I recently used this cookie cutter template having seen it in action at the SeptemRSE conference. I then spent three weeks trying to make sphinx work with my code (I have never used sphinx before). It turned out a particular doc-string in pandas.core.frame doesn't play nicely with numpydoc unless you have the `sphinx.ext.napoleon` extension enabled. 

Given that a lot of scientific python projects will probably use pandas DataFrames, and that many of the people you want to use this cookie cutter template may not have used sphinx before, this PR adds the extension to the list in `docs/source/conf.py` to save them the pain.